### PR TITLE
fix swift import by renaming the function with "default" prefix

### DIFF
--- a/MSGraphSDK/Extensions/MSGraphClient+DefaultConfiguration.h
+++ b/MSGraphSDK/Extensions/MSGraphClient+DefaultConfiguration.h
@@ -46,6 +46,6 @@
  Creates a client using settings from [MSGraphClientConfiguration defaultConfiguration]. Auth provider must be set beforehand.
  @warning With this method, the onus is on the developer to ensure the MSAuthenticationProvider is in a state ready to create auth headers before making client requests.
  */
-+ (MSGraphClient*)client;
++ (MSGraphClient*)defaultClient;
 
 @end

--- a/MSGraphSDK/Extensions/MSGraphClient+DefaultConfiguration.m
+++ b/MSGraphSDK/Extensions/MSGraphClient+DefaultConfiguration.m
@@ -31,7 +31,7 @@
     [self.logger setLogLevel:level];
 }
 
-+ (MSGraphClient*)client {
++ (MSGraphClient*)defaultClient {
     return [MSGraphClient clientWithConfig:[MSGraphClientConfiguration defaultConfiguration]];
 }
 


### PR DESCRIPTION
fixes #3 

Fixes swift bridging by replacing a name with a prefix "default". 

This is a breaking change, but will ensure consistency between objective-c and swift(using bridging).
