### PR TITLE
fix by using NS_SWIFT_NAME macro for swift translation

### DIFF
--- a/MSGraphSDK/Extensions/MSGraphClient+DefaultConfiguration.h
+++ b/MSGraphSDK/Extensions/MSGraphClient+DefaultConfiguration.h
@@ -46,6 +46,6 @@
  Creates a client using settings from [MSGraphClientConfiguration defaultConfiguration]. Auth provider must be set beforehand.
  @warning With this method, the onus is on the developer to ensure the MSAuthenticationProvider is in a state ready to create auth headers before making client requests.
  */
-+ (MSGraphClient*)client;
++ (MSGraphClient*)client NS_SWIFT_NAME(defaultClient());;
 
 @end


### PR DESCRIPTION
fixes #3 

This fixes the bridging to swift by adding a macro.
This is NOT a breaking change, however, now the names are different between objective-c and swift
